### PR TITLE
Support for NC13

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,6 +11,6 @@
 	<category>Tool</category>
 	<dependencies>
 		<owncloud min-version="10.0" max-version="11.0"/>
-		<nextcloud min-version="9.0" max-version="12.0"/>
+		<nextcloud min-version="9.0" max-version="13.0"/>
 	</dependencies>
 </info>


### PR DESCRIPTION
Add support for NC13. Tested with folders + files, in combination with Group Folders. Seems to work fine. The app refuses to enable unless this is changed.